### PR TITLE
Add headers to support site nginx config

### DIFF
--- a/files/default.conf
+++ b/files/default.conf
@@ -40,6 +40,10 @@ server {
     root /var/www/html;
     index index.html;
 
+    add_header Content-Security-Policy "default-src *; style-src 'self' 'unsafe-inline'";
+    add_header Strict-Transport-Security 'max-age=6307200; includeSubDomains; preload';
+    add_header X-Content-Type-Options nosniff;
+
     include sites-available/redirections.conf;
 
     location / {


### PR DESCRIPTION
## Description
Add headers requested by Mozilla Observatory to `https://support.kobotoolbox.org`'s nginx config