### PR TITLE
redirect for training.kobotoolbox.org

### DIFF
--- a/files/default.conf
+++ b/files/default.conf
@@ -87,6 +87,18 @@ server {
 }
 
 server {
+    server_name training.kobotoolbox.org;
+    listen 80;
+    listen [::]:80;
+    root /var/www/html;
+    index index.html;
+
+    location / {
+        return 301 https://academy.kobotoolbox.org/courses/humanitarian-needs-assessment;
+    }
+}
+
+server {
     server_name kobo.ngo www.kobo.ngo;
     listen 80;
     listen [::]:80;


### PR DESCRIPTION
Add redirect from training.kobotoolbox.org to https://academy.kobotoolbox.org/courses/humanitarian-needs-assessment 

[Notion task](https://www.notion.so/kobotoolbox/URL-redirect-for-training-0968d5e429ea4b53afad572f7bba1be4)

