### PR TITLE
chore(healthcheck): add healthcheck

### DIFF
--- a/manifest/ingress.yml
+++ b/manifest/ingress.yml
@@ -10,6 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/load-balancer-name: redirects
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/healthcheck-path: "/service_health/"
 spec:
   rules:
   - host: "kobotoolbox.org"


### PR DESCRIPTION
This adds the healthcheck to the ingress so that the ELB reports the correct healthy host count instead of unhealthy hosts